### PR TITLE
Setup gem spec for release

### DIFF
--- a/rack-anystatus.gemspec
+++ b/rack-anystatus.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/danielgroves/rack-anystatus"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Removes the host-blocking configuration from `gemspec` file to allow first push. 